### PR TITLE
Mute people sending discord nitro links

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -38,3 +38,4 @@ suggestion_sheet: '1PaaBuj7httWJX5go5taMWrhzX3jf5oJ1GNqHFp5gWuA'
 tags_sheet: '1ITwXFYSrlw_asQ1lGJusE-w0xT50Mmy__0yxl2URqHI'
 mod_vote_chan: 582915500254691328
 warn_channel: 739993490108448798
+muted_role: 565820528435396619

--- a/modsbot.py
+++ b/modsbot.py
@@ -46,6 +46,26 @@ class MODSBot(commands.Bot):
 
     async def on_message(self, message):
         if message.author.bot: return
+        
+        # Mute for spam
+        spam = False
+        if re.search(r'http://|https://', message.content):
+            if re.search('discord', message.content) and re.search('nitro', message.content):
+                spam = True
+            for i in message.embeds:
+                print(i.title + i.description)
+                if re.search('discord', i.title + i.description, re.I) and re.search('nitro', i.title + i.description, re.I):
+                    spam = True
+        if spam:
+            try:
+                log_message = f'Muted {message.author.mention} for spam:\n```{message.content}```'
+                await message.delete()
+                await message.author.add_roles(message.guild.get_role(self.config['muted_role']))
+                await message.guild.get_channel(self.config['log_channel']).send(log_message)
+            except Exception:
+                pass
+            return
+        
         if message.author.id in self.blacklist: return
         await self.process_commands(message)
 

--- a/modsbot.py
+++ b/modsbot.py
@@ -50,7 +50,7 @@ class MODSBot(commands.Bot):
         # Mute for spam
         spam = False
         if re.search(r'http://|https://', message.content):
-            if re.search('discord', message.content) and re.search('nitro', message.content):
+            if re.search('discord', message.content, re.I) and re.search('nitro', message.content, re.I):
                 spam = True
             for i in message.embeds:
                 print(i.title + i.description)


### PR DESCRIPTION
Checks for existence of hyperlink and existence of 'discord' and 'nitro' in message content, embed titles and descriptions. Assigns muted role and logs deleted message. Ignores bots.